### PR TITLE
Fixed bug "Fullscreen overlay does not resize on orientation changed"

### DIFF
--- a/source/src/ca/idi/tekla/TeclaApp.java
+++ b/source/src/ca/idi/tekla/TeclaApp.java
@@ -4,8 +4,6 @@
 
 package ca.idi.tekla;
 
-import ca.idi.tekla.util.Highlighter;
-import ca.idi.tekla.util.Persistence;
 import android.app.Application;
 import android.app.KeyguardManager;
 import android.app.KeyguardManager.KeyguardLock;
@@ -16,17 +14,20 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.media.AudioManager;
 import android.os.Build;
 import android.os.Handler;
 import android.os.PowerManager;
-import android.os.SystemClock;
 import android.os.PowerManager.WakeLock;
+import android.os.SystemClock;
 import android.provider.Settings;
 import android.speech.RecognizerIntent;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.widget.Toast;
+import ca.idi.tekla.util.Highlighter;
+import ca.idi.tekla.util.Persistence;
 
 public class TeclaApp extends Application {
 
@@ -46,6 +47,7 @@ public class TeclaApp extends Application {
 	public static final String ACTION_HIDE_IME = "ca.idi.tekla.ime.action.HIDE_IME";
 	public static final String ACTION_IME_CREATED = "ca.idi.tekla.ime.action.SOFT_IME_CREATED";
 	public static final String ACTION_START_FS_SWITCH_MODE = "ca.idi.tekla.ime.action.START_FS_SWITCH_MODE";
+	public static final String ACTION_RESTART_FS_SWITCH_MODE = "ca.idi.tekla.ime.action.RESTART_FS_SWITCH_MODE";
 	public static final String ACTION_STOP_FS_SWITCH_MODE = "ca.idi.tekla.ime.action.STOP_FS_SWITCH_MODE";
 	public static final String ACTION_INPUT_STRING = "ca.idi.tekla.ime.action.INPUT_STRING";
 	public static final String EXTRA_INPUT_STRING = "ca.idi.tekla.sep.extra.INPUT_STRING";
@@ -128,6 +130,22 @@ public class TeclaApp extends Application {
 		Log.d(TAG, "TECLA APP TERMINATED!");
 		super.onTerminate();
 	}
+	
+	/**
+	 * Called when the configuration changes. 
+	 * Used here to detect when the screen orientation changes
+	 * If fullscreen switch is enabled, it needs to change size
+	 * to fit the new screen orientation 
+	 */
+	@Override
+	public void onConfigurationChanged(Configuration config) {
+		super.onConfigurationChanged(config);
+		if(DEBUG) Log.d(TAG, "onConfigurationChanged");
+		if(persistence.isFullscreenSwitchEnabled()) {
+			if(DEBUG) Log.d(TAG, "Screen rotated while fullscreen switch enabled. Changing size.");
+			restartFullScreenSwitchMode();
+		}
+	}
 
 	// All intents will be processed here
 	private BroadcastReceiver mReceiver = new BroadcastReceiver() {
@@ -175,6 +193,11 @@ public class TeclaApp extends Application {
 	public void startFullScreenSwitchMode() {
 		if (DEBUG) Log.d(TAG, "Broadcasting start fullscreen switch mode intent...");
 		sendBroadcast(new Intent(ACTION_START_FS_SWITCH_MODE));
+	}
+	
+	public void restartFullScreenSwitchMode() {
+		if (DEBUG) Log.d(TAG, "Broadcasting restart fullscreen switch mode intent...");
+		sendBroadcast(new Intent(ACTION_RESTART_FS_SWITCH_MODE));
 	}
 
 	public void stopFullScreenSwitchMode() {

--- a/source/src/ca/idi/tekla/ime/TeclaIME.java
+++ b/source/src/ca/idi/tekla/ime/TeclaIME.java
@@ -16,6 +16,11 @@
 
 package ca.idi.tekla.ime;
 
+import java.io.FileDescriptor;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -26,8 +31,8 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.inputmethodservice.InputMethodService;
 import android.inputmethodservice.Keyboard;
-import android.inputmethodservice.KeyboardView;
 import android.inputmethodservice.Keyboard.Key;
+import android.inputmethodservice.KeyboardView;
 import android.media.AudioManager;
 import android.os.Debug;
 import android.os.Handler;
@@ -54,17 +59,11 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.PopupWindow;
-
-import java.io.FileDescriptor;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.List;
-
+import ca.idi.tecla.sdk.SepManager;
+import ca.idi.tecla.sdk.SwitchEvent;
 import ca.idi.tekla.R;
 import ca.idi.tekla.TeclaApp;
 import ca.idi.tekla.TeclaPrefs;
-import ca.idi.tecla.sdk.SepManager;
-import ca.idi.tecla.sdk.SwitchEvent;
 import ca.idi.tekla.sep.SwitchEventProvider;
 import ca.idi.tekla.util.Highlighter;
 import ca.idi.tekla.util.Persistence;
@@ -602,12 +601,12 @@ public class TeclaIME extends InputMethodService
 				hideSoftIME();
 			}
 			if (action.equals(TeclaApp.ACTION_START_FS_SWITCH_MODE)) {
-				Log.d(TeclaApp.TAG, CLASS_TAG + "Received start fullscreen switch mode intent.");
-				startFullScreenSwitchMode(500);
+				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received start fullscreen switch mode intent.");
+				startFullScreenSwitchMode(500, true);
 			}
-			if (action.equals(TeclaApp.ACTION_STOP_FS_SWITCH_MODE)) {
-				Log.d(TeclaApp.TAG, CLASS_TAG + "Received stop fullscreen switch mode intent.");
-				stopFullScreenSwitchMode();
+			if (action.equals(TeclaApp.ACTION_RESTART_FS_SWITCH_MODE)) {
+				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received restart fullscreen switch mode intent.");
+				startFullScreenSwitchMode(500, false);
 			}
 			if (action.equals(Highlighter.ACTION_START_SCANNING)) {
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received start scanning IME intent.");
@@ -1403,6 +1402,7 @@ public class TeclaIME extends InputMethodService
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_SHOW_IME));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_HIDE_IME));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_START_FS_SWITCH_MODE));
+		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_RESTART_FS_SWITCH_MODE));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_STOP_FS_SWITCH_MODE));
 		registerReceiver(mReceiver, new IntentFilter(Highlighter.ACTION_START_SCANNING));
 		registerReceiver(mReceiver, new IntentFilter(Highlighter.ACTION_STOP_SCANNING));
@@ -1645,8 +1645,9 @@ public class TeclaIME extends InputMethodService
 	}
 
 
-	private void startFullScreenSwitchMode(int delay) {
+	private void startFullScreenSwitchMode(int delay, boolean showToast) {
 		mTeclaHandler.removeCallbacks(mCreateSwitchRunnable);
+		mCreateSwitchRunnable = new CreateSwitchRunnable (showToast);
 		mTeclaHandler.postDelayed(mCreateSwitchRunnable, delay);
 		if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Sent delayed broadcast to show fullscreen switch");
 	}
@@ -1654,7 +1655,18 @@ public class TeclaIME extends InputMethodService
 	/**
 	 * Runnable used to create full-screen switch overlay
 	 */
-	private Runnable mCreateSwitchRunnable = new Runnable () {
+	private Runnable mCreateSwitchRunnable = new CreateSwitchRunnable (true); 
+	
+	class CreateSwitchRunnable implements Runnable {
+		final boolean showToast;
+		
+		public CreateSwitchRunnable(boolean shouldShowToast) {
+			showToast = shouldShowToast;
+		}
+		
+		public CreateSwitchRunnable() {
+			showToast = true;
+		}
 
 		public void run() {
 			if (TeclaApp.highlighter.isSoftIMEShowing()) {
@@ -1671,14 +1683,15 @@ public class TeclaIME extends InputMethodService
 				mSwitchPopup.setWidth(display.getWidth());
 				mSwitchPopup.setHeight(display.getHeight());
 				mSwitchPopup.showAtLocation(mIMEView, Gravity.NO_GRAVITY, 0, 0);
-				TeclaApp.getInstance().showToast(R.string.fullscreen_enabled);
+				if (showToast) TeclaApp.getInstance().showToast(R.string.fullscreen_enabled);
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch shown");
 				evaluateStartScanning();
 			} else {
-				startFullScreenSwitchMode(1000);
+				startFullScreenSwitchMode(1000, showToast);
 			}
 		}
-	};
+		
+	}
 
 	/**
 	 * Listener for full-screen single switch long press


### PR DESCRIPTION
Fixed bug "Fullscreen overlay does not resize on orientation changed" (https://github.com/jorgesilva/TeclaAccess/issues/14).

Problem was caused by the fact that the fullscreen switch overlay
didn't change size/shape when the screen orientation changed. To fix this,
I've overridden onConfigurationChanged (which triggers when the orientation
changes) to send out a new intent, ACTION_RESTART_FS_SWITCH_MODE. This works
similarly to the ACTION_START_FS_SWITCH_MODE intent except that it won't
show the "Fullscreen switch enabled" toast.

To toggle the Toast, I modified mCreateSwitchRunnable to be an instance of
an inner class that takes a boolean argument, showToast. startFullScreenSwitchMode()
provides the boolean.

(Repeat of the identical commit to the master branch, as it should've gone in
develop).
