### PR TITLE
resolved - Speakerphones turn on automatically while using switch

### DIFF
--- a/source/src/ca/idi/tekla/sep/SwitchEventProvider.java
+++ b/source/src/ca/idi/tekla/sep/SwitchEventProvider.java
@@ -335,7 +335,6 @@ public class SwitchEventProvider extends Service implements Runnable {
 			//Screen should be on
 			//Answering should also unlock
 			TeclaApp.getInstance().answerCall();
-			TeclaApp.getInstance().useSpeakerphone();
 			// Assume phone is not ringing any more
 			mPhoneRinging = false;
 		} else if (!TeclaApp.persistence.isScreenOn()) {


### PR DESCRIPTION
Now the call will be received without turning the speakers on when a switch event is received.
