### PR TITLE
A slightly different fix for "Fullscreen overlay does not resize on orientation changed"

### DIFF
--- a/source/src/ca/idi/tekla/TeclaApp.java
+++ b/source/src/ca/idi/tekla/TeclaApp.java
@@ -4,8 +4,6 @@
 
 package ca.idi.tekla;
 
-import ca.idi.tekla.util.Highlighter;
-import ca.idi.tekla.util.Persistence;
 import android.app.Application;
 import android.app.KeyguardManager;
 import android.app.KeyguardManager.KeyguardLock;
@@ -16,17 +14,20 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.content.res.Configuration;
 import android.media.AudioManager;
 import android.os.Build;
 import android.os.Handler;
 import android.os.PowerManager;
-import android.os.SystemClock;
 import android.os.PowerManager.WakeLock;
+import android.os.SystemClock;
 import android.provider.Settings;
 import android.speech.RecognizerIntent;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.widget.Toast;
+import ca.idi.tekla.util.Highlighter;
+import ca.idi.tekla.util.Persistence;
 
 public class TeclaApp extends Application {
 
@@ -46,6 +47,7 @@ public class TeclaApp extends Application {
 	public static final String ACTION_HIDE_IME = "ca.idi.tekla.ime.action.HIDE_IME";
 	public static final String ACTION_IME_CREATED = "ca.idi.tekla.ime.action.SOFT_IME_CREATED";
 	public static final String ACTION_START_FS_SWITCH_MODE = "ca.idi.tekla.ime.action.START_FS_SWITCH_MODE";
+	public static final String ACTION_RESTART_FS_SWITCH_MODE = "ca.idi.tekla.ime.action.RESTART_FS_SWITCH_MODE";
 	public static final String ACTION_STOP_FS_SWITCH_MODE = "ca.idi.tekla.ime.action.STOP_FS_SWITCH_MODE";
 	public static final String ACTION_INPUT_STRING = "ca.idi.tekla.ime.action.INPUT_STRING";
 	public static final String EXTRA_INPUT_STRING = "ca.idi.tekla.sep.extra.INPUT_STRING";
@@ -128,6 +130,22 @@ public class TeclaApp extends Application {
 		Log.d(TAG, "TECLA APP TERMINATED!");
 		super.onTerminate();
 	}
+	
+	/**
+	 * Called when the configuration changes. 
+	 * Used here to detect when the screen orientation changes
+	 * If fullscreen switch is enabled, it needs to change size
+	 * to fit the new screen orientation 
+	 */
+	@Override
+	public void onConfigurationChanged(Configuration config) {
+		super.onConfigurationChanged(config);
+		if(DEBUG) Log.d(TAG, "onConfigurationChanged");
+		if(persistence.isFullscreenSwitchEnabled()) {
+			if(DEBUG) Log.d(TAG, "Screen rotated while fullscreen switch enabled. Changing size.");
+			restartFullScreenSwitchMode();
+		}
+	}
 
 	// All intents will be processed here
 	private BroadcastReceiver mReceiver = new BroadcastReceiver() {
@@ -175,6 +193,11 @@ public class TeclaApp extends Application {
 	public void startFullScreenSwitchMode() {
 		if (DEBUG) Log.d(TAG, "Broadcasting start fullscreen switch mode intent...");
 		sendBroadcast(new Intent(ACTION_START_FS_SWITCH_MODE));
+	}
+	
+	public void restartFullScreenSwitchMode() {
+		if (DEBUG) Log.d(TAG, "Broadcasting restart fullscreen switch mode intent...");
+		sendBroadcast(new Intent(ACTION_RESTART_FS_SWITCH_MODE));
 	}
 
 	public void stopFullScreenSwitchMode() {

--- a/source/src/ca/idi/tekla/TeclaApp.java
+++ b/source/src/ca/idi/tekla/TeclaApp.java
@@ -14,7 +14,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
-import android.content.res.Configuration;
 import android.media.AudioManager;
 import android.os.Build;
 import android.os.Handler;

--- a/source/src/ca/idi/tekla/TeclaApp.java
+++ b/source/src/ca/idi/tekla/TeclaApp.java
@@ -47,7 +47,6 @@ public class TeclaApp extends Application {
 	public static final String ACTION_HIDE_IME = "ca.idi.tekla.ime.action.HIDE_IME";
 	public static final String ACTION_IME_CREATED = "ca.idi.tekla.ime.action.SOFT_IME_CREATED";
 	public static final String ACTION_START_FS_SWITCH_MODE = "ca.idi.tekla.ime.action.START_FS_SWITCH_MODE";
-	public static final String ACTION_RESTART_FS_SWITCH_MODE = "ca.idi.tekla.ime.action.RESTART_FS_SWITCH_MODE";
 	public static final String ACTION_STOP_FS_SWITCH_MODE = "ca.idi.tekla.ime.action.STOP_FS_SWITCH_MODE";
 	public static final String ACTION_INPUT_STRING = "ca.idi.tekla.ime.action.INPUT_STRING";
 	public static final String EXTRA_INPUT_STRING = "ca.idi.tekla.sep.extra.INPUT_STRING";
@@ -130,22 +129,6 @@ public class TeclaApp extends Application {
 		Log.d(TAG, "TECLA APP TERMINATED!");
 		super.onTerminate();
 	}
-	
-	/**
-	 * Called when the configuration changes. 
-	 * Used here to detect when the screen orientation changes
-	 * If fullscreen switch is enabled, it needs to change size
-	 * to fit the new screen orientation 
-	 */
-	@Override
-	public void onConfigurationChanged(Configuration config) {
-		super.onConfigurationChanged(config);
-		if(DEBUG) Log.d(TAG, "onConfigurationChanged");
-		if(persistence.isFullscreenSwitchEnabled()) {
-			if(DEBUG) Log.d(TAG, "Screen rotated while fullscreen switch enabled. Changing size.");
-			restartFullScreenSwitchMode();
-		}
-	}
 
 	// All intents will be processed here
 	private BroadcastReceiver mReceiver = new BroadcastReceiver() {
@@ -193,11 +176,6 @@ public class TeclaApp extends Application {
 	public void startFullScreenSwitchMode() {
 		if (DEBUG) Log.d(TAG, "Broadcasting start fullscreen switch mode intent...");
 		sendBroadcast(new Intent(ACTION_START_FS_SWITCH_MODE));
-	}
-	
-	public void restartFullScreenSwitchMode() {
-		if (DEBUG) Log.d(TAG, "Broadcasting restart fullscreen switch mode intent...");
-		sendBroadcast(new Intent(ACTION_RESTART_FS_SWITCH_MODE));
 	}
 
 	public void stopFullScreenSwitchMode() {

--- a/source/src/ca/idi/tekla/ime/TeclaIME.java
+++ b/source/src/ca/idi/tekla/ime/TeclaIME.java
@@ -1657,9 +1657,9 @@ public class TeclaIME extends InputMethodService
 
 	private void startFullScreenSwitchMode(int delay, boolean showToast) {
 		mTeclaHandler.removeCallbacks(mCreateSwitchRunnable);
-		mCreateSwitchRunnable = new CreateSwitchRunnable (showToast);
+		//mCreateSwitchRunnable = new CreateSwitchRunnable (showToast);
 		mTeclaHandler.postDelayed(mCreateSwitchRunnable, delay);
-		if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Sent delayed broadcast to show fullscreen switch");
+		Log.d(TeclaApp.TAG, CLASS_TAG + "Sent delayed broadcast to show fullscreen switch");
 	}
 	
 	/**
@@ -1694,7 +1694,7 @@ public class TeclaIME extends InputMethodService
 				mSwitchPopup.setHeight(display.getHeight());
 				mSwitchPopup.showAtLocation(mIMEView, Gravity.NO_GRAVITY, 0, 0);
 				if (showToast) TeclaApp.getInstance().showToast(R.string.fullscreen_enabled);
-				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch shown");
+				Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch shown");
 				evaluateStartScanning();
 			} else {
 				startFullScreenSwitchMode(1000, showToast);

--- a/source/src/ca/idi/tekla/ime/TeclaIME.java
+++ b/source/src/ca/idi/tekla/ime/TeclaIME.java
@@ -228,6 +228,14 @@ public class TeclaIME extends InputMethodService
 		SepManager.stop(this);
 	}
 
+	
+	/**
+	 * Called when the configuration changes. 
+	 * Used here to detect when the screen orientation changes
+	 * If fullscreen switch is enabled, it needs to change size
+	 * to fit the new screen orientation, and the keyboard needs
+	 * altered as well.
+	 */
 	@Override
 	public void onConfigurationChanged(Configuration conf) {
 		if (!TextUtils.equals(conf.locale.toString(), mLocale)) {
@@ -237,7 +245,13 @@ public class TeclaIME extends InputMethodService
 		if (conf.orientation != mOrientation) {
 			commitTyped(getCurrentInputConnection());
 			mOrientation = conf.orientation;
-			startFullScreenSwitchMode(500, false);
+			
+			// If the fullscreen switch is enabled, change its size/shape
+			if(TeclaApp.persistence.isFullscreenSwitchEnabled()) {
+				if(TeclaApp.DEBUG) Log.d(TeclaApp.TAG, "Screen rotated while fullscreen switch enabled. Changing size.");
+				startFullScreenSwitchMode(500, false);
+			}
+				
 		}
 		if (mKeyboardSwitcher == null) {
 			mKeyboardSwitcher = new KeyboardSwitcher(this);
@@ -604,10 +618,6 @@ public class TeclaIME extends InputMethodService
 			if (action.equals(TeclaApp.ACTION_START_FS_SWITCH_MODE)) {
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received start fullscreen switch mode intent.");
 				startFullScreenSwitchMode(500, true);
-			}
-			if (action.equals(TeclaApp.ACTION_RESTART_FS_SWITCH_MODE)) {
-				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received restart fullscreen switch mode intent.");
-				startFullScreenSwitchMode(500, false);
 			}
 			if (action.equals(Highlighter.ACTION_START_SCANNING)) {
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received start scanning IME intent.");
@@ -1403,7 +1413,6 @@ public class TeclaIME extends InputMethodService
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_SHOW_IME));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_HIDE_IME));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_START_FS_SWITCH_MODE));
-		//registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_RESTART_FS_SWITCH_MODE));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_STOP_FS_SWITCH_MODE));
 		registerReceiver(mReceiver, new IntentFilter(Highlighter.ACTION_START_SCANNING));
 		registerReceiver(mReceiver, new IntentFilter(Highlighter.ACTION_STOP_SCANNING));

--- a/source/src/ca/idi/tekla/ime/TeclaIME.java
+++ b/source/src/ca/idi/tekla/ime/TeclaIME.java
@@ -16,6 +16,11 @@
 
 package ca.idi.tekla.ime;
 
+import java.io.FileDescriptor;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -26,8 +31,8 @@ import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.inputmethodservice.InputMethodService;
 import android.inputmethodservice.Keyboard;
-import android.inputmethodservice.KeyboardView;
 import android.inputmethodservice.Keyboard.Key;
+import android.inputmethodservice.KeyboardView;
 import android.media.AudioManager;
 import android.os.Debug;
 import android.os.Handler;
@@ -54,17 +59,11 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.PopupWindow;
-
-import java.io.FileDescriptor;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.List;
-
+import ca.idi.tecla.sdk.SepManager;
+import ca.idi.tecla.sdk.SwitchEvent;
 import ca.idi.tekla.R;
 import ca.idi.tekla.TeclaApp;
 import ca.idi.tekla.TeclaPrefs;
-import ca.idi.tecla.sdk.SepManager;
-import ca.idi.tecla.sdk.SwitchEvent;
 import ca.idi.tekla.sep.SwitchEventProvider;
 import ca.idi.tekla.util.Highlighter;
 import ca.idi.tekla.util.Persistence;
@@ -602,12 +601,12 @@ public class TeclaIME extends InputMethodService
 				hideSoftIME();
 			}
 			if (action.equals(TeclaApp.ACTION_START_FS_SWITCH_MODE)) {
-				Log.d(TeclaApp.TAG, CLASS_TAG + "Received start fullscreen switch mode intent.");
-				startFullScreenSwitchMode(500);
+				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received start fullscreen switch mode intent.");
+				startFullScreenSwitchMode(500, true);
 			}
-			if (action.equals(TeclaApp.ACTION_STOP_FS_SWITCH_MODE)) {
-				Log.d(TeclaApp.TAG, CLASS_TAG + "Received stop fullscreen switch mode intent.");
-				stopFullScreenSwitchMode();
+			if (action.equals(TeclaApp.ACTION_RESTART_FS_SWITCH_MODE)) {
+				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received restart fullscreen switch mode intent.");
+				startFullScreenSwitchMode(500, false);
 			}
 			if (action.equals(Highlighter.ACTION_START_SCANNING)) {
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received start scanning IME intent.");
@@ -1403,6 +1402,7 @@ public class TeclaIME extends InputMethodService
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_SHOW_IME));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_HIDE_IME));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_START_FS_SWITCH_MODE));
+		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_RESTART_FS_SWITCH_MODE));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_STOP_FS_SWITCH_MODE));
 		registerReceiver(mReceiver, new IntentFilter(Highlighter.ACTION_START_SCANNING));
 		registerReceiver(mReceiver, new IntentFilter(Highlighter.ACTION_STOP_SCANNING));
@@ -1645,8 +1645,9 @@ public class TeclaIME extends InputMethodService
 	}
 
 
-	private void startFullScreenSwitchMode(int delay) {
+	private void startFullScreenSwitchMode(int delay, boolean showToast) {
 		mTeclaHandler.removeCallbacks(mCreateSwitchRunnable);
+		mCreateSwitchRunnable = new CreateSwitchRunnable (showToast);
 		mTeclaHandler.postDelayed(mCreateSwitchRunnable, delay);
 		if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Sent delayed broadcast to show fullscreen switch");
 	}
@@ -1654,7 +1655,18 @@ public class TeclaIME extends InputMethodService
 	/**
 	 * Runnable used to create full-screen switch overlay
 	 */
-	private Runnable mCreateSwitchRunnable = new Runnable () {
+	private Runnable mCreateSwitchRunnable = new CreateSwitchRunnable (true); 
+	
+	class CreateSwitchRunnable implements Runnable {
+		final boolean showToast;
+		
+		public CreateSwitchRunnable(boolean shouldShowToast) {
+			showToast = shouldShowToast;
+		}
+		
+		public CreateSwitchRunnable() {
+			showToast = true;
+		}
 
 		public void run() {
 			if (TeclaApp.highlighter.isSoftIMEShowing()) {
@@ -1671,14 +1683,15 @@ public class TeclaIME extends InputMethodService
 				mSwitchPopup.setWidth(display.getWidth());
 				mSwitchPopup.setHeight(display.getHeight());
 				mSwitchPopup.showAtLocation(mIMEView, Gravity.NO_GRAVITY, 0, 0);
-				TeclaApp.getInstance().showToast(R.string.fullscreen_enabled);
+				if (showToast) TeclaApp.getInstance().showToast(R.string.fullscreen_enabled);
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch shown");
 				evaluateStartScanning();
 			} else {
-				startFullScreenSwitchMode(1000);
+				startFullScreenSwitchMode(1000, showToast);
 			}
 		}
-	};
+		
+	}
 
 	/**
 	 * Listener for full-screen single switch long press

--- a/source/src/ca/idi/tekla/ime/TeclaIME.java
+++ b/source/src/ca/idi/tekla/ime/TeclaIME.java
@@ -237,6 +237,7 @@ public class TeclaIME extends InputMethodService
 		if (conf.orientation != mOrientation) {
 			commitTyped(getCurrentInputConnection());
 			mOrientation = conf.orientation;
+			startFullScreenSwitchMode(500, false);
 		}
 		if (mKeyboardSwitcher == null) {
 			mKeyboardSwitcher = new KeyboardSwitcher(this);
@@ -1402,7 +1403,7 @@ public class TeclaIME extends InputMethodService
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_SHOW_IME));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_HIDE_IME));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_START_FS_SWITCH_MODE));
-		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_RESTART_FS_SWITCH_MODE));
+		//registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_RESTART_FS_SWITCH_MODE));
 		registerReceiver(mReceiver, new IntentFilter(TeclaApp.ACTION_STOP_FS_SWITCH_MODE));
 		registerReceiver(mReceiver, new IntentFilter(Highlighter.ACTION_START_SCANNING));
 		registerReceiver(mReceiver, new IntentFilter(Highlighter.ACTION_STOP_SCANNING));

--- a/source/src/ca/idi/tekla/ime/TeclaIME.java
+++ b/source/src/ca/idi/tekla/ime/TeclaIME.java
@@ -619,6 +619,10 @@ public class TeclaIME extends InputMethodService
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received start fullscreen switch mode intent.");
 				startFullScreenSwitchMode(500, true);
 			}
+			if (action.equals(TeclaApp.ACTION_STOP_FS_SWITCH_MODE)) {
+				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received stop fullscreen switch mode intent.");
+				stopFullScreenSwitchMode();
+			}
 			if (action.equals(Highlighter.ACTION_START_SCANNING)) {
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received start scanning IME intent.");
 				evaluateStartScanning();
@@ -1657,9 +1661,9 @@ public class TeclaIME extends InputMethodService
 
 	private void startFullScreenSwitchMode(int delay, boolean showToast) {
 		mTeclaHandler.removeCallbacks(mCreateSwitchRunnable);
-		//mCreateSwitchRunnable = new CreateSwitchRunnable (showToast);
+		mCreateSwitchRunnable = new CreateSwitchRunnable (showToast);
 		mTeclaHandler.postDelayed(mCreateSwitchRunnable, delay);
-		Log.d(TeclaApp.TAG, CLASS_TAG + "Sent delayed broadcast to show fullscreen switch");
+		if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Sent delayed broadcast to show fullscreen switch");
 	}
 	
 	/**
@@ -1694,7 +1698,7 @@ public class TeclaIME extends InputMethodService
 				mSwitchPopup.setHeight(display.getHeight());
 				mSwitchPopup.showAtLocation(mIMEView, Gravity.NO_GRAVITY, 0, 0);
 				if (showToast) TeclaApp.getInstance().showToast(R.string.fullscreen_enabled);
-				Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch shown");
+				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch shown");
 				evaluateStartScanning();
 			} else {
 				startFullScreenSwitchMode(1000, showToast);

--- a/source/src/ca/idi/tekla/ime/TeclaIME.java
+++ b/source/src/ca/idi/tekla/ime/TeclaIME.java
@@ -202,7 +202,6 @@ public class TeclaIME extends InputMethodService
 		registerReceiver(mReceiver, new IntentFilter(AudioManager.RINGER_MODE_CHANGED_ACTION));
 
 		initTeclaA11y();
-
 	}
 	
 	private void initSuggest(String locale) {
@@ -246,12 +245,12 @@ public class TeclaIME extends InputMethodService
 			commitTyped(getCurrentInputConnection());
 			mOrientation = conf.orientation;
 			
-			// If the fullscreen switch is enabled, change its size/shape
-			if(TeclaApp.persistence.isFullscreenSwitchEnabled()) {
-				if(TeclaApp.DEBUG) Log.d(TeclaApp.TAG, "Screen rotated while fullscreen switch enabled. Changing size.");
-				startFullScreenSwitchMode(500, false);
+			// If the fullscreen switch is enabled, change its size/shape to match
+			if(isFullScreenShowing()) {
+				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, "Screen rotated while fullscreen switch enabled. Changing size.");
+				Display display = getDisplay();
+				mSwitchPopup.update(display.getWidth(), display.getHeight());
 			}
-				
 		}
 		if (mKeyboardSwitcher == null) {
 			mKeyboardSwitcher = new KeyboardSwitcher(this);
@@ -617,7 +616,7 @@ public class TeclaIME extends InputMethodService
 			}
 			if (action.equals(TeclaApp.ACTION_START_FS_SWITCH_MODE)) {
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received start fullscreen switch mode intent.");
-				startFullScreenSwitchMode(500, true);
+				startFullScreenSwitchMode(500);
 			}
 			if (action.equals(TeclaApp.ACTION_STOP_FS_SWITCH_MODE)) {
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Received stop fullscreen switch mode intent.");
@@ -1659,9 +1658,8 @@ public class TeclaIME extends InputMethodService
 	}
 
 
-	private void startFullScreenSwitchMode(int delay, boolean showToast) {
+	private void startFullScreenSwitchMode(int delay) {
 		mTeclaHandler.removeCallbacks(mCreateSwitchRunnable);
-		mCreateSwitchRunnable = new CreateSwitchRunnable (showToast);
 		mTeclaHandler.postDelayed(mCreateSwitchRunnable, delay);
 		if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Sent delayed broadcast to show fullscreen switch");
 	}
@@ -1669,18 +1667,7 @@ public class TeclaIME extends InputMethodService
 	/**
 	 * Runnable used to create full-screen switch overlay
 	 */
-	private Runnable mCreateSwitchRunnable = new CreateSwitchRunnable (true); 
-	
-	class CreateSwitchRunnable implements Runnable {
-		final boolean showToast;
-		
-		public CreateSwitchRunnable(boolean shouldShowToast) {
-			showToast = shouldShowToast;
-		}
-		
-		public CreateSwitchRunnable() {
-			showToast = true;
-		}
+	private Runnable mCreateSwitchRunnable = new Runnable () {
 
 		public void run() {
 			if (TeclaApp.highlighter.isSoftIMEShowing()) {
@@ -1697,15 +1684,14 @@ public class TeclaIME extends InputMethodService
 				mSwitchPopup.setWidth(display.getWidth());
 				mSwitchPopup.setHeight(display.getHeight());
 				mSwitchPopup.showAtLocation(mIMEView, Gravity.NO_GRAVITY, 0, 0);
-				if (showToast) TeclaApp.getInstance().showToast(R.string.fullscreen_enabled);
+				TeclaApp.getInstance().showToast(R.string.fullscreen_enabled);
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch shown");
 				evaluateStartScanning();
 			} else {
-				startFullScreenSwitchMode(1000, showToast);
+				startFullScreenSwitchMode(1000);
 			}
 		}
-		
-	}
+	};
 
 	/**
 	 * Listener for full-screen single switch long press

--- a/source/src/ca/idi/tekla/util/Persistence.java
+++ b/source/src/ca/idi/tekla/util/Persistence.java
@@ -8,6 +8,8 @@ import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.util.Log;
+import ca.idi.tekla.TeclaApp;
 
 public class Persistence {
 	
@@ -125,7 +127,9 @@ public class Persistence {
 	}
 
 	public boolean isFullscreenSwitchEnabled() {
-		return shared_prefs.getBoolean(PREF_FULLSCREEN_SWITCH, false);
+		boolean enabled = shared_prefs.getBoolean(PREF_FULLSCREEN_SWITCH, false);
+		Log.d(TeclaApp.TAG, "Checking if fullscreenswitch enabled " + enabled);
+		return enabled;
 	}
 
 	public boolean isSelfScanningEnabled() {

--- a/source/src/ca/idi/tekla/util/Persistence.java
+++ b/source/src/ca/idi/tekla/util/Persistence.java
@@ -8,8 +8,6 @@ import android.bluetooth.BluetoothAdapter;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
-import android.util.Log;
-import ca.idi.tekla.TeclaApp;
 
 public class Persistence {
 	
@@ -127,9 +125,7 @@ public class Persistence {
 	}
 
 	public boolean isFullscreenSwitchEnabled() {
-		boolean enabled = shared_prefs.getBoolean(PREF_FULLSCREEN_SWITCH, false);
-		Log.d(TeclaApp.TAG, "Checking if fullscreenswitch enabled " + enabled);
-		return enabled;
+		return shared_prefs.getBoolean(PREF_FULLSCREEN_SWITCH, false);
 	}
 
 	public boolean isSelfScanningEnabled() {


### PR DESCRIPTION
Similar to [my previous fix](https://github.com/jorgesilva/TeclaAccess/pull/45) but I've now moved startFullScreenSwitchMode(500, false) (which recreates the overlay without showing the Toast) into the onConfigurationChanged method of TeclaIME, rather than having TeclaApp.onConfigurationChanged broadcast an Intent. The effect is exactly the same but the code is a little simpler.
