### PR TITLE
Fixed #16 - Repeat key on switch hold

### DIFF
--- a/source/src/ca/idi/tekla/ime/TeclaIME.java
+++ b/source/src/ca/idi/tekla/ime/TeclaIME.java
@@ -708,6 +708,10 @@ public class TeclaIME extends InputMethodService
 
 		if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Keycode: " + keyCodes[0]);
 		
+		//prevent by double call
+		if (isNaviKey(primaryCode) && when < mLastKeyTime + QUICK_PRESS)
+			return;
+
 		if (primaryCode != Keyboard.KEYCODE_DELETE || 
 				when > mLastKeyTime + QUICK_PRESS) {
 			mDeleteCount = 0;
@@ -1156,10 +1160,16 @@ public class TeclaIME extends InputMethodService
 	public void onPress(int primaryCode) {
 		vibrate();
 		playKeyClick(primaryCode);
+		if (isNaviKey(primaryCode)) {
+			mKeyCodes = new int[] {primaryCode};
+			mTeclaHandler.removeCallbacks(mRepeatKeyRunnable);
+			mTeclaHandler.postDelayed(mRepeatKeyRunnable, TeclaApp.persistence.getScanDelay());
+		}
 	}
 
 	public void onRelease(int primaryCode) {
 		//vibrate();
+		mTeclaHandler.removeCallbacks(mRepeatKeyRunnable);
 	}
 
 	// update flags for silent mode
@@ -1547,6 +1557,11 @@ public class TeclaIME extends InputMethodService
 			//Selected item is a row
 			TeclaApp.highlighter.doSelectRow();
 		}
+	}
+
+	private boolean isNaviKey(int keycode) {
+		return ((keycode >= KeyEvent.KEYCODE_DPAD_UP) && (keycode <= KeyEvent.KEYCODE_DPAD_CENTER))
+				|| (keycode == KeyEvent.KEYCODE_BACK);
 	}
 
 	private boolean isSpecialKey(int keycode) {

--- a/source/src/ca/idi/tekla/ime/TeclaIME.java
+++ b/source/src/ca/idi/tekla/ime/TeclaIME.java
@@ -709,7 +709,9 @@ public class TeclaIME extends InputMethodService
 		if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Keycode: " + keyCodes[0]);
 		
 		//prevent by double call
-		if (isNaviKey(primaryCode) && when < mLastKeyTime + QUICK_PRESS)
+		if (isNaviKey(primaryCode)
+				&& !TeclaApp.persistence.isInverseScanningEnabled()
+				&& when < mLastKeyTime + QUICK_PRESS)
 			return;
 
 		if (primaryCode != Keyboard.KEYCODE_DELETE || 
@@ -1160,7 +1162,7 @@ public class TeclaIME extends InputMethodService
 	public void onPress(int primaryCode) {
 		vibrate();
 		playKeyClick(primaryCode);
-		if (isNaviKey(primaryCode)) {
+		if (isNaviKey(primaryCode) && !TeclaApp.persistence.isInverseScanningEnabled()) {
 			mKeyCodes = new int[] {primaryCode};
 			mTeclaHandler.removeCallbacks(mRepeatKeyRunnable);
 			mTeclaHandler.postDelayed(mRepeatKeyRunnable, TeclaApp.persistence.getScanDelay());


### PR DESCRIPTION
I used the mechanism that was already implemented. Now when onPress will be called mRepeatKeyRunnable  will be activated and in onRelease will be deactivated. Fixes #16

Signed-off-by: Konrad Olczak kolczak87@gmail.com
