### PR TITLE
#24 resolved - Pressing back key cancels the connection with the shield

### DIFF
--- a/source/src/ca/idi/tekla/TeclaPrefs.java
+++ b/source/src/ca/idi/tekla/TeclaPrefs.java
@@ -30,6 +30,8 @@ import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnCancelListener;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
@@ -362,7 +364,14 @@ implements SharedPreferences.OnSharedPreferenceChangeListener {
 
 	private void showDiscoveryDialog() {
 		mProgressDialog = ProgressDialog.show(this, "", 
-				getString(R.string.searching_for_shields), true, true);
+				getString(R.string.searching_for_shields), true, true, new OnCancelListener(){
+
+					public void onCancel(DialogInterface arg0) {
+						if(mBluetoothAdapter != null && mBluetoothAdapter.isDiscovering()){
+							mBluetoothAdapter.cancelDiscovery();
+						}
+						
+					}});
 	}
 
 	private void closeDialog() {

--- a/source/src/ca/idi/tekla/TeclaPrefs.java
+++ b/source/src/ca/idi/tekla/TeclaPrefs.java
@@ -369,6 +369,8 @@ implements SharedPreferences.OnSharedPreferenceChangeListener {
 					public void onCancel(DialogInterface arg0) {
 						if(mBluetoothAdapter != null && mBluetoothAdapter.isDiscovering()){
 							mBluetoothAdapter.cancelDiscovery();
+							//since we have cancelled the discovery the check state needs to be reset
+							mPrefConnectToShield.setChecked(false);
 						}
 						
 					}});


### PR DESCRIPTION
Added a OnCancelListener() which listens for the dialog cancelled event and if received cancels the discovery in process if any.
Solves issue #24.
