### PR TITLE
Solved issue #26  Confirmation should be asked for references which can disconnect Tecla Shield 

### DIFF
--- a/source/res/values/strings.xml
+++ b/source/res/values/strings.xml
@@ -283,6 +283,11 @@
 	<string name="no_voice_input_available">No speech recognition applications available!</string>
 	<string name="no_voice_actions_installed">Voice Actions is not installed!</string>
 
+	<!--  Alert when disconnecting the shield -->
+  	<string name="shield_disconnect_confirmation_msg">Are you sure you want to disconnect the shield?</string>
+  	<string name="shield_disconnect_confirmation_yes">Yes</string>
+  	<string name="shield_disconnect_confirmation_no">No</string>
+	
 	<!-- Tecla: Titles and labels -->
 	<string name="sep_label">Switch event provider</string>
 	<string name="voice_input">Tecla Voice Input</string>


### PR DESCRIPTION
Made use of inputaccesslib and ensured that the confirmation dialog box appears only when the shield is connected(connection status tracked by updating the mShieldConnected variable).
Also there were only 3 preferences which could have resulted in disconnection of shield(persistent keyboard, auto hide timeout and connect shield) keeping in mind the cyclic nature of the problem since changing one preference can cause a change in another and thus resulting in a chain action. 
I then moved their code inside the button clicked listener. Also since the code required for making the required dialog box was not much and each dialog box required its own OnClickListener() I created an AlertDialog box as and when required instead of creating a layout or a function for that purpose and calling it.
