### PR TITLE
fixed issue #38 - Change the scanning direction by swiping the screen

### DIFF
--- a/source/res/layout/activity_prefs.xml
+++ b/source/res/layout/activity_prefs.xml
@@ -86,6 +86,13 @@
             android:title="@string/scanning_category"
             android:key="scanning_settings">
 		<CheckBoxPreference
+			android:key="detect_swipe"
+			android:title="@string/detect_swipe"
+			android:summary="@string/detect_swipe_summary"
+			android:persistent="true"
+			android:defaultValue="false"
+			/>
+     	<CheckBoxPreference
 			android:key="self_scanning"
 			android:title="@string/self_scanning"
 			android:summary="@string/self_scanning_summary"

--- a/source/res/layout/popup_fullscreen_transparent.xml
+++ b/source/res/layout/popup_fullscreen_transparent.xml
@@ -5,4 +5,9 @@
     android:layout_height="fill_parent"
     android:enabled="true"
 	android:theme="@style/Theme.Transparent">
+	<android.gesture.GestureOverlayView
+	    android:id="@+id/gestures"
+	    android:layout_width="fill_parent" 
+	    android:layout_height="fill_parent"
+	    android:layout_weight="1.0" />
 </LinearLayout>

--- a/source/res/values/strings.xml
+++ b/source/res/values/strings.xml
@@ -253,6 +253,10 @@
     <!-- Category title for scanning -->
     <string name="scanning_category">Scanning settings</string>
 
+    <!-- Option to detect swipe in fullscreen switch mode -->
+	<string name="detect_swipe">Swipe to change scanning direction</string>
+	<string name="detect_swipe_summary">Changes the self-scanning direction when swiping left/right in fullscreen switch mode</string>
+    
     <!-- Option to enable self-scanning -->
 	<string name="self_scanning">Enable self-scanning</string>
 	<string name="self_scanning_summary">Scans the keyboard automatically</string>

--- a/source/src/ca/idi/tekla/TeclaPrefs.java
+++ b/source/src/ca/idi/tekla/TeclaPrefs.java
@@ -62,6 +62,8 @@ implements SharedPreferences.OnSharedPreferenceChangeListener {
 	private Preference mPrefAutohideTimeout;
 	private CheckBoxPreference mPrefConnectToShield;
 	private CheckBoxPreference mPrefFullScreenSwitch;
+
+	private CheckBoxPreference mPrefDetectSwipe;
 	private CheckBoxPreference mPrefSelfScanning;
 	private CheckBoxPreference mPrefInverseScanning;
 	private ProgressDialog mProgressDialog;
@@ -95,6 +97,7 @@ implements SharedPreferences.OnSharedPreferenceChangeListener {
 		mAutohideTimeoutDialog.setContentView(R.layout.dialog_autohide_timeout);
 		mPrefConnectToShield = (CheckBoxPreference) findPreference(Persistence.PREF_CONNECT_TO_SHIELD);
 		mPrefFullScreenSwitch = (CheckBoxPreference) findPreference(Persistence.PREF_FULLSCREEN_SWITCH);
+		mPrefDetectSwipe = (CheckBoxPreference) findPreference(Persistence.PREF_DETECT_SWIPE);
 		mPrefSelfScanning = (CheckBoxPreference) findPreference(Persistence.PREF_SELF_SCANNING);
 		mPrefInverseScanning = (CheckBoxPreference) findPreference(Persistence.PREF_INVERSE_SCANNING);
 		mScanSpeedDialog = new ScanSpeedDialog(this);
@@ -108,6 +111,7 @@ implements SharedPreferences.OnSharedPreferenceChangeListener {
 			mPrefPersistentKeyboard.setEnabled(false);
 			mPrefAutohideTimeout.setEnabled(false);
 			mPrefFullScreenSwitch.setEnabled(false);
+			mPrefDetectSwipe.setEnabled(false);
 			mPrefConnectToShield.setEnabled(false);
 			mPrefSelfScanning.setEnabled(false);
 			mPrefInverseScanning.setEnabled(false);
@@ -276,6 +280,7 @@ implements SharedPreferences.OnSharedPreferenceChangeListener {
 				mPrefInverseScanning.setEnabled(false);
 				mPrefFullScreenSwitch.setChecked(false);
 				mPrefConnectToShield.setChecked(false);
+				mPrefDetectSwipe.setEnabled(false);
 				TeclaApp.getInstance().requestHideIMEView();
 			}
 		}
@@ -322,6 +327,7 @@ implements SharedPreferences.OnSharedPreferenceChangeListener {
 					mPrefSelfScanning.setChecked(true);
 				}
 				mPrefAutohideTimeout.setEnabled(false);
+				mPrefDetectSwipe.setEnabled(true);
 				TeclaApp.persistence.setNeverHideNavigationKeyboard();
 			} else {
 				if (!mPrefConnectToShield.isChecked()) {
@@ -329,12 +335,16 @@ implements SharedPreferences.OnSharedPreferenceChangeListener {
 					mPrefSelfScanning.setEnabled(false);
 					mPrefInverseScanning.setChecked(false);
 					mPrefInverseScanning.setEnabled(false);
+					mPrefDetectSwipe.setEnabled(false);
 				}
 				if (mPrefPersistentKeyboard.isChecked()) {
 					mPrefAutohideTimeout.setEnabled(true);
 				}
 				TeclaApp.getInstance().stopFullScreenSwitchMode();
 			}
+		}
+		if(key.equals(Persistence.PREF_DETECT_SWIPE)){
+			TeclaApp.persistence.setSwipeDetectionEnabled(mPrefDetectSwipe.isChecked());
 		}
 		if (key.equals(Persistence.PREF_SELF_SCANNING)) {
 			if (mPrefSelfScanning.isChecked()) {

--- a/source/src/ca/idi/tekla/ime/TeclaIME.java
+++ b/source/src/ca/idi/tekla/ime/TeclaIME.java
@@ -24,6 +24,14 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.gesture.Gesture;
+import android.gesture.GestureLibraries;
+import android.gesture.GestureLibrary;
+import android.gesture.GestureOverlayView;
+import android.gesture.GesturePoint;
+import android.gesture.GestureStroke;
+import android.gesture.Prediction;
+import android.graphics.Point;
 import android.inputmethodservice.InputMethodService;
 import android.inputmethodservice.Keyboard;
 import android.inputmethodservice.KeyboardView;
@@ -159,6 +167,8 @@ public class TeclaIME extends InputMethodService
 	private String mWordSeparators;
 	private String mSentenceSeparators;
 
+	private static final float CLICK_THRESHOLD =  10.0f;
+
 	Handler mHandler = new Handler() {
 		@Override
 		public void handleMessage(Message msg) {
@@ -198,7 +208,6 @@ public class TeclaIME extends InputMethodService
 		mOrientation = conf.orientation;
 
 		mVibrateDuration = getResources().getInteger(R.integer.vibrate_duration_ms);
-
 		// register to receive ringer mode changes for silent mode
 		registerReceiver(mReceiver, new IntentFilter(AudioManager.RINGER_MODE_CHANGED_ACTION));
 
@@ -1383,12 +1392,13 @@ public class TeclaIME extends InputMethodService
 	 */
 	private static final String CLASS_TAG = "IME: ";
 
+
 	//TODO: Try moving these variables to TeclaApp class
 	private String mVoiceInputString;
 	private int mLastKeyboardMode, mLastFullKeyboardMode;
 	private boolean mShieldConnected, mRepeating;
 	private PopupWindow mSwitchPopup;
-	private View mSwitch;
+	private GestureOverlayView mSwitch;
 	private Handler mTeclaHandler;
 	private int[] mKeyCodes;
 	private boolean mIsNavKbdTimedOut;
@@ -1661,11 +1671,11 @@ public class TeclaIME extends InputMethodService
 				Display display = getDisplay();
 				if (mSwitchPopup == null) {
 					//Create single-switch pop-up
-					mSwitch = getLayoutInflater().inflate(R.layout.popup_fullscreen_transparent, null);
-					mSwitch.setOnTouchListener(mSwitchTouchListener);
-					mSwitch.setOnClickListener(mSwitchClickListener);
+					View mPopupLayout = getLayoutInflater().inflate(R.layout.popup_fullscreen_transparent, null);
+					mSwitchPopup = new PopupWindow(mPopupLayout);
+					mSwitch = (GestureOverlayView) mSwitchPopup.getContentView().findViewById(R.id.gestures);
+					mSwitch.addOnGestureListener(mGestureListener);
 					mSwitch.setOnLongClickListener(mSwitchLongPressListener);
-					mSwitchPopup = new PopupWindow(mSwitch);
 				}
 				if (mSwitchPopup.isShowing()) mSwitchPopup.dismiss();
 				mSwitchPopup.setWidth(display.getWidth());
@@ -1696,27 +1706,26 @@ public class TeclaIME extends InputMethodService
 		}
 	};
 
-	/**
-	 * Listener for full-screen switch actions
-	 */
-	private View.OnTouchListener mSwitchTouchListener = new View.OnTouchListener() {
+	private GestureOverlayView.OnGestureListener mGestureListener = new GestureOverlayView.OnGestureListener() {
+
+		Point startPoint,endPoint;
 		
-		public boolean onTouch(View v, MotionEvent event) {
-			switch (event.getAction()) {
-			case MotionEvent.ACTION_DOWN:
-				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch down!");
-				mSwitch.setBackgroundResource(R.color.switch_pressed);
-				vibrate();
-				playKeyClick(KEYCODE_ENTER);
-				if (TeclaApp.persistence.isInverseScanningEnabled()) {
-					TeclaApp.highlighter.resumeSelfScanning();
-				} else {
-					selectHighlighted(false);
-				}
-				break;
-			case MotionEvent.ACTION_UP:
-				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch up!");
-				mSwitch.setBackgroundResource(android.R.color.transparent);
+		public void onGesture(GestureOverlayView overlay, MotionEvent event) {
+		}
+
+		public void onGestureCancelled(GestureOverlayView overlay,
+				MotionEvent event) {
+		}
+
+		public void onGestureEnded(GestureOverlayView overlay, MotionEvent event) {
+			endPoint = new Point((int)event.getX(),(int)event.getY());
+			if(startPoint == null)
+				startPoint = endPoint;
+			double gestureLength = Math.sqrt(Math.pow(endPoint.x-startPoint.x, 2)+Math.pow(endPoint.y-startPoint.y, 2));
+			int swipeDir = (endPoint.x-startPoint.x<0)?-1:1;
+			if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch up!");
+			mSwitch.setBackgroundResource(android.R.color.transparent);
+			if(gestureLength < CLICK_THRESHOLD || !TeclaApp.persistence.isSwipeDetectionEnabled()){
 				if (TeclaApp.persistence.isInverseScanningEnabled()) {
 					if (TeclaApp.persistence.isInverseScanningChanged()) {
 						//Ignore event right after Inverse Scanning is Enabled
@@ -1728,22 +1737,40 @@ public class TeclaIME extends InputMethodService
 						selectHighlighted(false);
 					}
 				}
-				break;
-			default:
-				break;
+				else{
+					selectHighlighted(false);
+				}
 			}
-			return false;
+			else if(TeclaApp.persistence.isSwipeDetectionEnabled()){
+				//User can keep press down the screen then slide and then up the touch
+				//which will cause inverse scanning to improperly function
+				//therefore this remedy
+				if (TeclaApp.persistence.isInverseScanningEnabled()) {
+					TeclaApp.highlighter.pauseSelfScanning();
+				}
+				if(swipeDir == -1){
+					TeclaApp.highlighter.setScanDirection(Highlighter.HIGHLIGHT_PREV);
+				}
+				else if(swipeDir == 1 ){
+					TeclaApp.highlighter.setScanDirection(Highlighter.HIGHLIGHT_NEXT);
+				}
+				}
+			}
+	
+		public void onGestureStarted(GestureOverlayView overlay,
+				MotionEvent event) {
+			startPoint = new Point((int)event.getX(),(int)event.getY());
+			if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch down!");
+			mSwitch.setBackgroundResource(R.color.switch_pressed);
+			vibrate();
+			playKeyClick(KEYCODE_ENTER);
+			if (TeclaApp.persistence.isInverseScanningEnabled()) {
+				TeclaApp.highlighter.resumeSelfScanning();
+			}
 		}
-	};
 
-	private View.OnClickListener mSwitchClickListener =  new View.OnClickListener() {
-		
-		public void onClick(View v) {
-			//Doing this here again because the ACTION_UP event in the onTouch listener doesn't always work.
-			mSwitch.setBackgroundResource(android.R.color.transparent);
-		}
 	};
-
+	
 	private void stopFullScreenSwitchMode() {
 		if (isFullScreenShowing()) {
 			mSwitchPopup.dismiss();

--- a/source/src/ca/idi/tekla/util/Highlighter.java
+++ b/source/src/ca/idi/tekla/util/Highlighter.java
@@ -35,6 +35,7 @@ public class Highlighter {
 	private boolean mWasShowingVariants;
 	private TeclaKeyboardView mIMEView;
 	private Handler mHandler;
+	private int scanDirection = Highlighter.HIGHLIGHT_NEXT;
 
 	public Highlighter(Context context) {
 
@@ -209,7 +210,7 @@ public class Highlighter {
 		public void run() {
 			final long start = SystemClock.uptimeMillis();
 			if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Scanning to next item");
-			move(Highlighter.HIGHLIGHT_NEXT);
+			move(scanDirection);
 			mHandler.postAtTime(this, start + TeclaApp.persistence.getScanDelay());
 		}
 	};
@@ -226,6 +227,7 @@ public class Highlighter {
 			}
 		}
 	};
+
 
 	/** 
 	 * Start highlighting the current keyboard. Automatically handles single row keyboards.
@@ -247,6 +249,7 @@ public class Highlighter {
 				mScanRowCounter = 0;
 			}
 		}
+		scanDirection = Highlighter.HIGHLIGHT_NEXT;
 		restoreHighlight();
 	}
 
@@ -300,4 +303,11 @@ public class Highlighter {
 		mHandler.sendMessage(msg);  
 	}
 
+	public void setScanDirection(int scanDirection) {
+		this.scanDirection = scanDirection;
+	}
+
+	public int getScanDirection() {
+		return scanDirection;
+	}
 }

--- a/source/src/ca/idi/tekla/util/Persistence.java
+++ b/source/src/ca/idi/tekla/util/Persistence.java
@@ -23,6 +23,7 @@ public class Persistence {
 	public static final String PREF_CONNECT_TO_SHIELD = "shield_connect";
 	public static final String PREF_SHIELD_ADDRESS = "shield_address";
 	public static final String PREF_FULLSCREEN_SWITCH = "fullscreen_switch";
+	public static final String PREF_DETECT_SWIPE = "detect_swipe";
 	public static final String PREF_SELF_SCANNING = "self_scanning";
 	public static final String PREF_INVERSE_SCANNING = "inverse_scanning";
 	public static final String PREF_SCAN_DELAY_INT = "scan_delay_int";
@@ -155,6 +156,14 @@ public class Persistence {
 	public void setScanDelay(int delay) {
 		prefs_editor.putInt(PREF_SCAN_DELAY_INT, delay);
 		prefs_editor.commit();
+	}
+	
+	public void setSwipeDetectionEnabled(boolean set){
+		prefs_editor.putBoolean(PREF_DETECT_SWIPE, set);
+	}
+
+	public boolean isSwipeDetectionEnabled(){
+		return shared_prefs.getBoolean(PREF_DETECT_SWIPE, false);
 	}
 
 	public int getScanDelay() {

--- a/source/src/ca/idi/tekla/util/Persistence.java
+++ b/source/src/ca/idi/tekla/util/Persistence.java
@@ -160,6 +160,7 @@ public class Persistence {
 	
 	public void setSwipeDetectionEnabled(boolean set){
 		prefs_editor.putBoolean(PREF_DETECT_SWIPE, set);
+		prefs_editor.commit();
 	}
 
 	public boolean isSwipeDetectionEnabled(){


### PR DESCRIPTION
Added a preference in the preference tree for setting the mentioned feature on or off. Now users can change the direction of scanning just by swiping left or right when the full screen switch mode is on. If the length of swipe is less than a threshold length then it is treated as a click otherwise it is treated as a gesture. If this preference is off then whatever be the length of swipe it is treated as a click. This feature has been sufficiently debugged and tested.
Solves issues #38.
