### PR TITLE
Allows for bluetooth to be turned on from TeclaPrefs. 

### DIFF
--- a/source/AndroidManifest.xml
+++ b/source/AndroidManifest.xml
@@ -28,7 +28,7 @@
         <activity
             android:name=".TeclaPrefs"
             android:label="@string/english_ime_settings"
-            android:noHistory="true" >
+            android:noHistory="false" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/source/src/ca/idi/tekla/TeclaPrefs.java
+++ b/source/src/ca/idi/tekla/TeclaPrefs.java
@@ -467,7 +467,7 @@ implements SharedPreferences.OnSharedPreferenceChangeListener{
 			if (mBluetoothAdapter == null) {
 				showAlert(R.string.shield_connect_summary_BT_nosupport);
 			} else if (!mBluetoothAdapter.isEnabled()) {
-				showAlert(R.string.shield_connect_summary_BT_disabled);
+				startActivity(new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE));
 			}
 		}
 		return super.onPreferenceTreeClick(preferenceScreen, preference);


### PR DESCRIPTION
This can be done when "Connect to Tecla Shield" is pressed when bluetooth is off. 'no history' removed from manifest.

Fixed #148
