### PR TITLE
Preference to turn on bluetooth will trigger connection to the shield up on successful activation of bluetooth.

### DIFF
--- a/source/src/ca/idi/tekla/TeclaPrefs.java
+++ b/source/src/ca/idi/tekla/TeclaPrefs.java
@@ -373,7 +373,20 @@ implements SharedPreferences.OnSharedPreferenceChangeListener{
 		mBluetoothAdapter.startDiscovery();
 		showDiscoveryDialog();
 	}
+	
+	BroadcastReceiver btReceiver = new BroadcastReceiver() {
+		@Override
+		public void onReceive(Context context, Intent intent) {
+			// TODO Auto-generated method stub
+			int state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, -1);
+			if (state == BluetoothAdapter.STATE_ON){
+				Log.i(TeclaApp.TAG, "Bluetooth Turned On Successfully");
+				discoverShield();
+			}
+		}
+	};
 
+	
 	// All intents will be processed here
 	private BroadcastReceiver mReceiver = new BroadcastReceiver() {
 
@@ -467,6 +480,8 @@ implements SharedPreferences.OnSharedPreferenceChangeListener{
 			if (mBluetoothAdapter == null) {
 				showAlert(R.string.shield_connect_summary_BT_nosupport);
 			} else if (!mBluetoothAdapter.isEnabled()) {
+				registerReceiver(btReceiver, new IntentFilter(
+						BluetoothAdapter.ACTION_STATE_CHANGED));
 				startActivity(new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE));
 			}
 		}


### PR DESCRIPTION
When preference for "Connect to shield" is checked and bluetooth is disabled, user will be prompted to enable bluetooth. Upon successful activation of bluetooth, application will now automatically attempt to connect to a nearby shield.

Fixed #150
