### PR TITLE
Fixed checkbox for connecting to shield in preferences

### DIFF
--- a/source/src/ca/idi/tekla/TeclaPrefs.java
+++ b/source/src/ca/idi/tekla/TeclaPrefs.java
@@ -383,6 +383,7 @@ implements SharedPreferences.OnSharedPreferenceChangeListener{
 			if (state == BluetoothAdapter.STATE_ON){
 				Log.i(TeclaApp.TAG, "Bluetooth Turned On Successfully");
 				discoverShield();
+				mPrefConnectToShield.setChecked(true);
 			}
 		}
 	};

--- a/source/src/ca/idi/tekla/TeclaPrefs.java
+++ b/source/src/ca/idi/tekla/TeclaPrefs.java
@@ -382,7 +382,6 @@ implements SharedPreferences.OnSharedPreferenceChangeListener{
 			int state = intent.getIntExtra(BluetoothAdapter.EXTRA_STATE, -1);
 			if (state == BluetoothAdapter.STATE_ON){
 				Log.i(TeclaApp.TAG, "Bluetooth Turned On Successfully");
-				discoverShield();
 				mPrefConnectToShield.setChecked(true);
 			}
 		}


### PR DESCRIPTION
Preference will now be properly checked off upon connection to the Tecla shield.

Fixed #168
