### PR TITLE
Set long press reset on enable/disable inverse scanning. Fixes #189

### DIFF
--- a/source/AndroidManifest.xml
+++ b/source/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="ca.idi.tekla"
-    android:versionCode="32"
-    android:versionName="1.0" >
+    android:versionCode="33"
+    android:versionName="1.0.1" >
 
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />

--- a/source/src/ca/idi/tekla/TeclaPrefs.java
+++ b/source/src/ca/idi/tekla/TeclaPrefs.java
@@ -679,9 +679,11 @@ implements SharedPreferences.OnSharedPreferenceChangeListener{
 			if (mPrefInverseScanning.isChecked()) {
 				mPrefSelfScanning.setChecked(false);
 				TeclaApp.persistence.setInverseScanningChanged();
+				TeclaApp.persistence.setFullResetTimeout(Persistence.MAX_FULL_RESET_TIMEOUT);
 			} else {
 				TeclaApp.getInstance().stopScanningTeclaIME();
 				if (!mPrefSelfScanning.isChecked()) {
+					TeclaApp.persistence.setFullResetTimeout(Persistence.MIN_FULL_RESET_TIMEOUT);
 					mPrefFullScreenSwitch.setChecked(false);
 					if (!mPrefConnectToShield.isChecked()) {
 						mPrefTempDisconnect.setChecked(false);

--- a/source/src/ca/idi/tekla/ime/TeclaIME.java
+++ b/source/src/ca/idi/tekla/ime/TeclaIME.java
@@ -2309,14 +2309,17 @@ public class TeclaIME extends ca.idi.tecla.framework.TeclaIMEService
 	private View.OnTouchListener mSwitchTouchListener = new View.OnTouchListener() {
 		
 		public boolean onTouch(View v, MotionEvent event) {
+			int changes = SwitchEvent.MASK_SWITCH_E1;
+			int states = SwitchEvent.SWITCH_STATES_DEFAULT;
 			switch (event.getAction()) {
 			case MotionEvent.ACTION_DOWN:
-				injectSwitchEvent(new SwitchEvent(SwitchEvent.MASK_SWITCH_E1)); //Primary switch pressed
+				states &= ~changes;
+				injectSwitchEvent(changes, states); //Primary switch pressed
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch down!");
 				mSwitch.setBackgroundResource(R.color.switch_pressed);
 				break;
 			case MotionEvent.ACTION_UP:
-				injectSwitchEvent(new SwitchEvent()); //Switches released
+				injectSwitchEvent(changes, states); //Primary switch released
 				if (TeclaApp.DEBUG) Log.d(TeclaApp.TAG, CLASS_TAG + "Fullscreen switch up!");
 				mSwitch.setBackgroundResource(android.R.color.transparent);
 				break;

--- a/source/src/ca/idi/tekla/util/Persistence.java
+++ b/source/src/ca/idi/tekla/util/Persistence.java
@@ -35,6 +35,8 @@ public class Persistence extends ca.idi.tecla.framework.Persistence {
 	public static final String DEFAULT_MORSE_KEY_MODE = "0";
 	public static final int DEFAULT_MORSE_TIME_UNIT = 150;
 	public static final int DEFAULT_FULL_RESET_TIMEOUT = 3;
+	public static final int MIN_FULL_RESET_TIMEOUT = 3;
+	public static final int MAX_FULL_RESET_TIMEOUT = 40;
 	public static final int DEFAULT_SCAN_DELAY = 1000;
 	public static final int DEFAULT_REPEAT_FREQ = 750;
 	public static final int MAX_SCAN_DELAY = 3000;


### PR DESCRIPTION
Also implemented a bug fix that broke the fullscreen switch mode on inverse scanning
