### PR TITLE
Enabling speakerphone after a short delay. Fixes #203

### DIFF
--- a/framework/src/ca/idi/tecla/framework/SwitchEventProvider.java
+++ b/framework/src/ca/idi/tecla/framework/SwitchEventProvider.java
@@ -150,20 +150,26 @@ public class SwitchEventProvider extends Service {
 						//if enabled in prefs, activate speaker phone  whenever the phone is off the hook
 						TeclaStatic.logD(CLASS_TAG, "Phone off the hook");
 						if(TeclaApp.persistence.isSpeakerphoneEnabled()){
-							/* Turn the speaker on after a short delay,
-							 *  so that auto-turnoff-speaker is completed 
-							 *  by PhoneUtils.java (Android 4.1 onwards)
-							 *  
-							 *  Increase the delay if the problem still occurs
-							 */
-							int delay = 200;// in ms
-							new Timer().schedule(new TimerTask() {          
-							    @Override
-							    public void run() {
-									TeclaStatic.logD(CLASS_TAG, "Enabling Speaker");
-							    	TeclaApp.getInstance().useSpeakerphone();      
-							    }
-							}, delay);
+							
+              if (android.os.Build.VERSION.SDK_INT >= 16){ 
+								/* Turn the speaker on after a short delay,
+								 *  so that Jellybean's auto-turnoff-speaker is completed 
+								 *  by PhoneUtils.java (API 16 onwards)
+								 *  
+								 *  Increase the delay if the problem still occurs
+								 */
+								int delay = 200;// in ms
+								new Timer().schedule(new TimerTask() {          
+										@Override
+										public void run() {
+										TeclaStatic.logD(CLASS_TAG, "Enabling Speaker");
+											TeclaApp.getInstance().useSpeakerphone();
+										}
+								}, delay);
+              }
+              else { //no delay
+								TeclaApp.getInstance().useSpeakerphone();
+              }
 							
 						}
 						

--- a/framework/src/ca/idi/tecla/framework/TeclaApp.java
+++ b/framework/src/ca/idi/tecla/framework/TeclaApp.java
@@ -179,8 +179,14 @@ public class TeclaApp extends Application {
 		buttonUp.putExtra(Intent.EXTRA_KEY_EVENT, new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_HEADSETHOOK));
 		sendOrderedBroadcast(buttonUp, "android.permission.CALL_PRIVILEGED");
 		
+		/* Not required to enable speaker here, as the listener in 
+		 * ca.idi.tecla.framework.SwitchEventProvider changed from outgoing-call to Off-hook,
+		 * handling both incoming and outgoing calls
+		  
 		if(TeclaApp.persistence.isSpeakerphoneEnabled())
 				useSpeakerphone();
+				
+		*/
 	}
 
 	public void postDelayedFullReset(long delay) {


### PR DESCRIPTION
This delay allows Jellybean's auto-disable-speakerphone
procedure to complete first and then enable the speaker manually.
Increase the 'delay' in ca.idi.tecla.framework.SwitchEventProvider.onReceive if the problem still occurs.
